### PR TITLE
Set default no challenge for hidden_captcha uiowa_bar_search_form.

### DIFF
--- a/uiowa_bar.install
+++ b/uiowa_bar.install
@@ -214,3 +214,19 @@ function uiowa_bar_update_7202() {
   variable_set('uiowa_bar_link2_title', '');
   variable_set('uiowa_bar_link2_url', '');
 }
+
+/**
+ * If Hidden CAPTCHA, set No Challenge.
+ */
+function uiowa_bar_update_7203() {
+  // If Hidden CAPTCHA is enabled.
+  if (module_exists('hidden_captcha')) {
+    // If Default challenge on non-listed forms is checked.
+    if (variable_get(captcha_default_challenge_on_nonlisted_forms) == '1') {
+      // Set the default challenge type for uiowa_bar_search_form to No Challenge.
+      db_insert('captcha_points')
+        ->fields(array('form_id' => 'uiowa_bar_search_form',))
+        ->execute();
+    }
+  }
+}


### PR DESCRIPTION
If hidden captcha is enabled and "Default challenge on non-listed forms" is checked, the uiowa_bar gets a visible captcha challenge.

![screen shot 2017-04-03 at 11 35 02 am](https://cloud.githubusercontent.com/assets/4663676/24621864/ae01b798-1868-11e7-9ba5-b8b705edc378.png)

This update hooks checks for both and sets a default "no challenge" to the search form.
