### PR TITLE
scope CSE to this site by default

### DIFF
--- a/config/install/uiowa_bar.settings.yml
+++ b/config/install/uiowa_bar.settings.yml
@@ -1,4 +1,4 @@
 uiowa_bar:
   wordmark: uiowa
   cse_engine_id: 015014862498168032802:ben09oibdpm
-  cse_scope: 0
+  cse_scope: 1


### PR DESCRIPTION
This PR scopes the CSE to "this site" by default.

This seems to be the most frequent use-case and is the default setting in the 7.x branches.