### PR TITLE
specify color and background color of textbox label

### DIFF
--- a/css/uiowa-bar.css
+++ b/css/uiowa-bar.css
@@ -68,6 +68,8 @@
 }
 
 #uiowa-bar #uiowa-search label {
+  color: #ffffff;
+  background-color: #000000;
   position: absolute;
   left: -10000px;
   top: auto;


### PR DESCRIPTION
Compliance Sheriff is flagging the contrast ratio between the search box label text and its background color. This PR specifies the color and background color of the label to ensure sufficient contrast (even though the label is positioned off-screen).
