### PR TITLE
wrangle mobile/desktop display based on uiowa_bootstrap

### DIFF
--- a/src/Form/SearchForm.php
+++ b/src/Form/SearchForm.php
@@ -34,7 +34,9 @@ class SearchForm extends FormBase {
         'placeholder' => 'Search this site',
         'class' => [
           'form-control',
+          'form-control-sm',
           'mt-0',
+          'mx-sm-2',
         ]
       ],
       '#maxlength' => '256',
@@ -46,8 +48,10 @@ class SearchForm extends FormBase {
       '#name' => 'btnG',
       '#attributes' => [
         'class' => [
-          'ml-1',
-          'mr-0',
+          'mx-0',
+          'form-control-sm',
+          'btn-sm',
+          'btn-dark',
         ]
       ],
     ];

--- a/templates/uiowa-bar.html.twig
+++ b/templates/uiowa-bar.html.twig
@@ -4,8 +4,8 @@
   {% elseif config.wordmark == 'uihc'  %}
     {{ include('@uiowa_bar/parts/uihc-wordmark.html.twig') }}
   {% endif %}
-  <div id="uiowa-search" class="uiowa-bar--navbar d-flex align-items-center">
-    <ul class="uiowa-bar--navbar--links d-inline-flex mb-0">
+  <div id="uiowa-search" class="uiowa-bar--navbar d-flex align-items-center mt-2 mt-sm-0">
+    <ul class="uiowa-bar--navbar--links d-inline-flex mb-0 px-0">
       {% if config.link_1_title and config.link_1_url %}
         <li class="mr-2"><a href="{{ config.link_1_url }}">{{ config.link_1_title }}</a></li>
       {% endif %}


### PR DESCRIPTION
With uiowa_bootstrap base styles, the uiowa_bar needs a little wrangling. Still using a lot of utility classes for now.

## Before:
<img width="554" alt="screen shot 2019-01-30 at 1 08 58 pm" src="https://user-images.githubusercontent.com/4663676/52009538-d34a4680-2498-11e9-98f4-b44f19147f9a.png">

<img width="408" alt="screen shot 2019-01-30 at 1 09 20 pm" src="https://user-images.githubusercontent.com/4663676/52009540-d34a4680-2498-11e9-8015-aaefb142b9cd.png">

## After:
<img width="571" alt="screen shot 2019-01-30 at 2 04 58 pm" src="https://user-images.githubusercontent.com/4663676/52009541-d34a4680-2498-11e9-924e-7db957bf2970.png">

<img width="388" alt="screen shot 2019-01-30 at 2 06 08 pm" src="https://user-images.githubusercontent.com/4663676/52009542-d3e2dd00-2498-11e9-82b0-dd5914277057.png">